### PR TITLE
Ability to set ignoring parameter for IgnorePointer widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [1.5.1+2]
-* Ability to set `ignoring` parameter for `IgnorePointer` widget (contributed by @agordn).
+* Ability to set `ignoring` parameter for `IgnorePointer` widget (contributed by @agordn52).
 
 ## [1.5.1+1]
 Change [StyledToast] from StatelessWidget to StatefulWidget.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.5.1+2]
+* Ability to set `ignoring` parameter for `IgnorePointer` widget (contributed by @agordn).
+
 ## [1.5.1+1]
 Change [StyledToast] from StatelessWidget to StatefulWidget.
 Add [onInitState] to StyledToast and StyledToastTheme.

--- a/README.md
+++ b/README.md
@@ -365,8 +365,8 @@ fullWidth            | bool (default false)(Full width parameter that the width 
 isHideKeyboard       | bool (default false)(Is hide keyboard when toast show)
 animationBuilder     | CustomAnimationBuilder (Builder method for custom animation)
 reverseAnimBuilder   | CustomAnimationBuilder (Builder method for custom reverse animation)
+isIgnoring           | bool (default true)
 onInitState          | OnInitStateCallback (When toast widget [initState], this callback will be called)
-isIgnoringPointer    | bool (default true)
 
 
 
@@ -403,8 +403,8 @@ fullWidth            | bool (default false)(Full width parameter that the width 
 isHideKeyboard       | bool (default false)(Is hide keyboard when toast show)
 animationBuilder     | CustomAnimationBuilder (Builder method for custom animation)
 reverseAnimBuilder   | CustomAnimationBuilder (Builder method for custom reverse animation)
-onInitState          | OnInitStateCallback (When toast widget [initState], this callback will be called)
 isIgnoring           | bool (default true)
+onInitState          | OnInitStateCallback (When toast widget [initState], this callback will be called)
 
 
 
@@ -434,8 +434,8 @@ reverseCurve         | Curve (default Curves.linear)
 isHideKeyboard       | bool (default false)(Is hide keyboard when toast show)
 animationBuilder     | CustomAnimationBuilder (Builder method for custom animation)
 reverseAnimBuilder   | CustomAnimationBuilder (Builder method for custom reverse animation)
-onInitState          | OnInitStateCallback (When toast widget [initState], this callback will be called)
 isIgnoring           | bool (default true)
+onInitState          | OnInitStateCallback (When toast widget [initState], this callback will be called)
 
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Beautify toast with a series of animations and make toast more beautiful.
 
 ```yaml
 dependencies:
-  flutter_styled_toast: ^1.5.1+1
+  flutter_styled_toast: ^1.5.1+2
 ```
 
 ```dart
@@ -366,6 +366,7 @@ isHideKeyboard       | bool (default false)(Is hide keyboard when toast show)
 animationBuilder     | CustomAnimationBuilder (Builder method for custom animation)
 reverseAnimBuilder   | CustomAnimationBuilder (Builder method for custom reverse animation)
 onInitState          | OnInitStateCallback (When toast widget [initState], this callback will be called)
+isIgnoringPointer    | bool (default true)
 
 
 
@@ -403,6 +404,7 @@ isHideKeyboard       | bool (default false)(Is hide keyboard when toast show)
 animationBuilder     | CustomAnimationBuilder (Builder method for custom animation)
 reverseAnimBuilder   | CustomAnimationBuilder (Builder method for custom reverse animation)
 onInitState          | OnInitStateCallback (When toast widget [initState], this callback will be called)
+isIgnoring           | bool (default true)
 
 
 
@@ -433,6 +435,7 @@ isHideKeyboard       | bool (default false)(Is hide keyboard when toast show)
 animationBuilder     | CustomAnimationBuilder (Builder method for custom animation)
 reverseAnimBuilder   | CustomAnimationBuilder (Builder method for custom reverse animation)
 onInitState          | OnInitStateCallback (When toast widget [initState], this callback will be called)
+isIgnoring           | bool (default true)
 
 
 ## Example

--- a/lib/src/styled_toast.dart
+++ b/lib/src/styled_toast.dart
@@ -66,6 +66,7 @@ ToastFuture showToast(
   bool isHideKeyboard,
   CustomAnimationBuilder animationBuilder,
   CustomAnimationBuilder reverseAnimBuilder,
+  bool isIgnoring = true,
   OnInitStateCallback onInitState,
 }) {
   context = context != null ? context : currentContext;
@@ -134,6 +135,7 @@ ToastFuture showToast(
     isHideKeyboard: isHideKeyboard,
     animationBuilder: animationBuilder,
     reverseAnimBuilder: reverseAnimBuilder,
+    isIgnoring: isIgnoring,
     onInitState: onInitState,
   );
 }
@@ -162,6 +164,7 @@ ToastFuture showToastWidget(
   bool isHideKeyboard,
   CustomAnimationBuilder animationBuilder,
   CustomAnimationBuilder reverseAnimBuilder,
+  bool isIgnoring = true,
   OnInitStateCallback onInitState,
 }) {
   OverlayEntry entry;
@@ -223,6 +226,7 @@ ToastFuture showToastWidget(
 
   entry = OverlayEntry(builder: (ctx) {
     return IgnorePointer(
+      ignoring: isIgnoring,
       child: _StyledToastWidget(
         duration: duration,
         animDuration: animDuration,
@@ -364,6 +368,9 @@ class StyledToast extends StatefulWidget {
   ///Custom animation builder method
   final CustomAnimationBuilder reverseAnimBuilder;
 
+  ///Is the input ignored for the toast.
+  final bool isIgnoring;
+
   ///When toast widget [initState], this callback will be called.
   final OnInitStateCallback onInitState;
 
@@ -398,6 +405,7 @@ class StyledToast extends StatefulWidget {
     this.isHideKeyboard,
     this.animationBuilder,
     this.reverseAnimBuilder,
+    this.isIgnoring = true,
     this.onInitState,
   }) : super(key: key);
 
@@ -495,6 +503,7 @@ class _StyledToastState extends State<StyledToast> {
           isHideKeyboard: widget.isHideKeyboard,
           animationBuilder: widget.animationBuilder,
           reverseAnimBuilder: widget.reverseAnimBuilder,
+          isIgnoring: widget.isIgnoring,
           onInitState: widget.onInitState,
         ),
       ),

--- a/lib/src/styled_toast_theme.dart
+++ b/lib/src/styled_toast_theme.dart
@@ -98,6 +98,9 @@ class StyledToastTheme extends InheritedWidget {
   ///Custom animation builder method
   final CustomAnimationBuilder reverseAnimBuilder;
 
+  ///Is the input ignored for the toast.
+  final bool isIgnoring;
+
   ///When toast widget [initState], this callback will be called.
   final OnInitStateCallback onInitState;
 
@@ -130,6 +133,7 @@ class StyledToastTheme extends InheritedWidget {
     this.isHideKeyboard,
     this.animationBuilder,
     this.reverseAnimBuilder,
+    this.isIgnoring,
     this.onInitState,
   }) : super(child: child);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_styled_toast
 description: A Styled Toast Flutter package. You can highly customize toast ever.Beautify toast with a series of animations and make toast more beautiful.
-version: 1.5.1+1
+version: 1.5.1+2
 homepage: https://github.com/JackJonson/flutter_styled_toast
 email: yswing1@gmail.com
 


### PR DESCRIPTION
### v1.5.1+2
This PR will allow you to set the `ignoring` parameter for `IgnorePointer` widget.

**Why?** 
So we can use interactive widgets for the `showToastWidget()`method.
Includes tweaks to the readme, changelog and pubspec.yaml file. 