### PR TITLE
Fix critical localization bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,117 +1,113 @@
-## [2.2.1 null-safety]
-Fix warnings.
+## [2.3.0 null-safety]
 
+Remove custom locale delegates override and introduce better internal structure.
+
+## [2.2.1 null-safety]
+
+Fix warnings.
 
 ## [2.2.0 null-safety]
+
 Upgrade to Flutter 3.10.x.
 
-
 ## [2.1.3 null-safety]
+
 Fix warnings.
 
-
 ## [2.1.2 null-safety]
+
 Add multiple animation demo in the example.
 Upgrade example android embedding to v2.
 Fix warnings.
 
-
 ## [2.0.0 null-safety]
+
 Migrate to null safety.
 Remove deprecated param movingOnWindowChange.
 
-
 ## [1.5.2+3]
+
 Format.
 
-
 ## [1.5.2+2]
+
 Fix bug.
 
-
 ## [1.5.2+1]
+
 * Ability to set `ignoring` parameter for `IgnorePointer` widget (contributed by @agordn52).
 * Permanent toast, when set [duration] to Duration.zero, toast won't dismiss automatically.
 
-
 ## [1.5.1+1]
+
 Change [StyledToast] from StatelessWidget to StatefulWidget.
 Add [onInitState] to StyledToast and StyledToastTheme.
 
-
 ## [1.5.0+2]
+
 Delete deprecated parameter [movingOnWindowChange] usage.
 
-
 ## [1.5.0+1]
+
 Add parameter isHideKeyboard (default is true), if true, when toast show, keyboard will be hidden.
 Add parameter animationBuilder, builder method for custom animation
 Add parameter reverseAnimBuilder, builder method for custom reverse animation
 Add parameter onInitState, toast widget initState callback.
 
-
 ## [1.4.0+1]
+
 Improve documentation.
 
-
 ## [1.4.0]
+
 Add fullWidth parameter, controls whether the width of default toast widget is full screen.
 Code optimization. 
 Fix the bug when dismiss toast.
 
-
 ## [1.3.2]
+
 Fix unused import.
 
-
 ## [1.3.1]
+
 Add locale as required parameter in StyledToast.
 Fix TextFields context menu exception with Flutter 1.17.0.
 
-
 ## [1.3.0]
+
 Add toast position: topLeft, topRight, centerLeft, centerRight, bottomLeft, bottomRight.
 Add custom size transition to support alignment in size transition animation. Fix size transition bug. Modify example.
-
 
 ## [1.2.1]
 
 Add start offset, reverse end offset in StyledToast.
-
 
 ## [1.2.0]
 
 Add axis, alignment support to rotate and size animation.
 Add start offset, end offset, reverse start offset, reverse end offset to slide animation.
 
-
 ## [1.1.0+5]
 
 Fix bugs.
-
 
 ## [1.1.0+4]
 
 Modify README.
 
-
 ## [1.1.0+3]
 
 Fix bugs.
 
-
 ## [1.1.0]
 
 Adding size animation sizeFade animation, fix bugs.
-
 
 ## [1.0.0]
 
 First release version
 features: showToast showToastWidget toast animation and reverse animation.
 
-
 ## [0.0.1]
 
 initial project
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flutter_styled_toast
 
-A Styled Toast Flutter package. 
+A Styled Toast Flutter package.
 You can highly customize toast ever.
 Beautify toast with a series of animations and make toast more beautiful.
 
@@ -9,6 +9,7 @@ Beautify toast with a series of animations and make toast more beautiful.
 <img src="https://raw.githubusercontent.com/JackJonson/flutter_styled_toast/master/screenshots/OverallAnimations.gif" width="50%">
 
 ## Null safety
+
 ```yaml
 dependencies:
   flutter_styled_toast: ^2.2.1
@@ -26,53 +27,52 @@ import 'package:flutter_styled_toast/flutter_styled_toast.dart';
 ```
 
 ```dart
-//Simple to use, no global configuration
-showToast("hello styled toast",context:context);
+// Simple to use, no global configuration
+showToast("hello styled toast", context: context);
 
-//Customize toast content widget, no global configuration
-showToastWidget(Text('hello styled toast'),context:context);
+// Customize toast content widget, no global configuration
+showToastWidget(Text('hello styled toast'), context: context);
 ```
 
 ```dart
 //Interactive toast, set [isIgnoring] false.
 showToastWidget(
-   Container(
-       padding: EdgeInsets.symmetric(horizontal: 18.0),
-       margin: EdgeInsets.symmetric(horizontal: 50.0),
-       decoration: ShapeDecoration(
-           shape: RoundedRectangleBorder(
-               borderRadius: BorderRadius.circular(5.0),
-           ),
-           color: Colors.green[600],
-       ),
-       child: Row(
-           children: [
-               Text(
-                   'Jump to new page',
-                   style: TextStyle(
-                       color: Colors.white,
-                   ),
-               ),
-               IconButton(
-                   onPressed: () {
-                       ToastManager().dismissAll(showAnim: true);
-                       Navigator.push(context,
-                           MaterialPageRoute(builder: (context) {
-                           return SecondPage();
-                       }));
-                   },
-                   icon: Icon(
-                       Icons.add_circle_outline_outlined,
-                       color: Colors.white,
-                   ),
-               ),
-           ],
-           mainAxisAlignment: MainAxisAlignment.spaceBetween,
-       ),
-   ),
-   context: context,
-   isIgnoring: false,
-   duration: Duration.zero,
+  Container(
+    padding: EdgeInsets.symmetric(horizontal: 18.0),
+    margin: EdgeInsets.symmetric(horizontal: 50.0),
+    decoration: ShapeDecoration(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(5.0),
+      ),
+      color: Colors.green[600],
+    ),
+    child: Row(
+      children: [
+        Text(
+          'Jump to new page',
+          style: TextStyle(
+            color: Colors.white,
+          ),
+        ),
+        IconButton(
+          onPressed: () {
+            ToastManager().dismissAll(showAnim: true);
+            Navigator.push(context, MaterialPageRoute(builder: (context) {
+              return SecondPage();
+            }));
+          },
+          icon: Icon(
+            Icons.add_circle_outline_outlined,
+            color: Colors.white,
+          ),
+        ),
+      ],
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+    ),
+  ),
+  context: context,
+  isIgnoring: false,
+  duration: Duration.zero,
 );
 ```
 
@@ -96,8 +96,7 @@ showToast('This is normal toast with animation',
    reverseCurve: Curves.linear,
 );
 
-```dart
-
+```
 
 ```dart
 ///Custom animation and custom reverse animation,
@@ -109,162 +108,165 @@ AnimationController mReverseController;
 @override
 void initState() {
   super.initState();
-  mController =
-      AnimationController(vsync: this, duration: Duration(milliseconds: 200));
-  mReverseController =
-      AnimationController(vsync: this, duration: Duration(milliseconds: 200));
+  mController = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: 200),
+    );
+    mReverseController = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: 200),
+    );
 }
 
-showToast('This is normal toast with custom animation',
-   context: context,
-   position: StyledToastPosition.bottom,
-   animDuration: Duration(seconds: 1),
-   duration: Duration(seconds: 4),
-   animationBuilder: (
-       BuildContext context,
-       AnimationController controller,
-       Duration duration,
-       Widget child,
-   ) {
-      return SlideTransition(
+showToast(
+      'This is normal toast with custom animation',
+      context: context,
+      position: StyledToastPosition.bottom,
+      animDuration: Duration(seconds: 1),
+      duration: Duration(seconds: 4),
+      animationBuilder: (
+        BuildContext context,
+        AnimationController controller,
+        Duration duration,
+        Widget child,
+      ) {
+        return SlideTransition(
           position: getAnimation<Offset>(
-          Offset(0.0, 3.0), Offset(0, 0), controller,
-          curve: Curves.bounceInOut),
+              Offset(0.0, 3.0), Offset(0, 0), controller,
+              curve: Curves.bounceInOut),
           child: child,
-      );
-   },
-   reverseAnimBuilder: (
-      BuildContext context,
-      AnimationController controller,
-      Duration duration,
-      Widget child,
-   ) {
-      return SlideTransition(
+        );
+      },
+      reverseAnimBuilder: (
+        BuildContext context,
+        AnimationController controller,
+        Duration duration,
+        Widget child,
+      ) {
+        return SlideTransition(
           position: getAnimation<Offset>(
-          Offset(0.0, 0.0), Offset(-3.0, 0), controller,
-          curve: Curves.bounceInOut),
+              Offset(0.0, 0.0), Offset(-3.0, 0), controller,
+              curve: Curves.bounceInOut),
           child: child,
-      );
-   },
-);
+        );
+      },
+    );
 
-```dart
-
+```
 
 ```dart
 ///Custom animation, custom reverse animation and custom animation controller
-showToast('This is normal toast with custom animation and controller',
-   context: context,
-   position: StyledToastPosition.bottom,
-   animDuration: Duration(seconds: 1),
-   duration: Duration(seconds: 4),
-   onInitState:(Duration toastDuration, Duration animDuration) async {
-      try {
-         await mController.forward().orCancel;
-         Future.delayed(toastDuration - animDuration, () async {
+showToast(
+      'This is normal toast with custom animation and controller',
+      context: context,
+      position: StyledToastPosition.bottom,
+      animDuration: Duration(seconds: 1),
+      duration: Duration(seconds: 4),
+      onInitState: (Duration toastDuration, Duration animDuration) async {
+        try {
+          await mController.forward().orCancel;
+          Future.delayed(toastDuration - animDuration, () async {
             await mReverseController.forward().orCancel;
             mController.reset();
             mReverseController.reset();
-         });
-      } on TickerCanceled {}
-   },
-   animationBuilder: (
-       BuildContext context,
-       AnimationController controller,
-       Duration duration,
-       Widget child,
-   ) {
-      return SlideTransition(
+          });
+        } on TickerCanceled {}
+      },
+      animationBuilder: (
+        BuildContext context,
+        AnimationController controller,
+        Duration duration,
+        Widget child,
+      ) {
+        return SlideTransition(
           position: getAnimation<Offset>(
-          Offset(0.0, 3.0), Offset(0, 0), controller,
-          curve: Curves.bounceInOut),
+              Offset(0.0, 3.0), Offset(0, 0), controller,
+              curve: Curves.bounceInOut),
           child: child,
-      );
-   },
-   reverseAnimBuilder: (
-      BuildContext context,
-      AnimationController controller,
-      Duration duration,
-      Widget child,
-   ) {
-      return SlideTransition(
+        );
+      },
+      reverseAnimBuilder: (
+        BuildContext context,
+        AnimationController controller,
+        Duration duration,
+        Widget child,
+      ) {
+        return SlideTransition(
           position: getAnimation<Offset>(
-          Offset(0.0, 0.0), Offset(-3.0, 0), controller,
-          curve: Curves.bounceInOut),
+              Offset(0.0, 0.0), Offset(-3.0, 0), controller,
+              curve: Curves.bounceInOut),
           child: child,
-      );
-   },
-);
+        );
+      },
+    );
 
-```dart
-
-
-
-Simple global configuration, wrap you app with StyledToast.
-```dart
-StyledToast(
-  locale: const Locale('en', 'US'),
-  child: MaterialApp(
-            title: appTitle,
-            showPerformanceOverlay: showPerformance,
-            home: LayoutBuilder(
-              builder: (BuildContext context, BoxConstraints constraints) {
-                return MyHomePage(
-                  title: appTitle,
-                  onSetting: onSettingCallback,
-                );
-              },
-            ),
-          ),
-);
 ```
 
-Highly Customizable global configuration
+Simple global configuration, wrap you app with StyledToast.
+
 ```dart
-StyledToast(
-  locale: const Locale('en', 'US'),  //You have to set this parameters to your locale
-  textStyle: TextStyle(fontSize: 16.0, color: Colors.white), //Default text style of toast
-  backgroundColor: Color(0x99000000),  //Background color of toast
-  borderRadius: BorderRadius.circular(5.0), //Border radius of toast
-  textPadding: EdgeInsets.symmetric(horizontal: 17.0, vertical: 10.0),//The padding of toast text
-  toastPositions: StyledToastPosition.bottom, //The position of toast
-  toastAnimation: StyledToastAnimation.fade,  //The animation type of toast
-  reverseAnimation: StyledToastAnimation.fade, //The reverse animation of toast (display When dismiss toast)
-  curve: Curves.fastOutSlowIn,  //The curve of animation
-  reverseCurve: Curves.fastLinearToSlowEaseIn, //The curve of reverse animation
-  duration: Duration(seconds: 4), //The duration of toast showing, when set [duration] to Duration.zero, toast won't dismiss automatically.
-  animDuration: Duration(seconds: 1), //The duration of animation(including reverse) of toast 
-  dismissOtherOnShow: true,  //When we show a toast and other toast is showing, dismiss any other showing toast before.
-  movingOnWindowChange: true, //When the window configuration changes, move the toast.
-  fullWidth: false, //Whether the toast is full screen (subtract the horizontal margin)
-  isHideKeyboard: false, //Is hide keyboard when toast show
-  isIgnoring: true, //Is the input ignored for the toast
-  animationBuilder: (BuildContext context,AnimationController controller,Duration duration,Widget child,){  // Builder method for custom animation
-     return SlideTransition(
-        position: getAnimation<Offset>(Offset(0.0, 3.0),Offset(0,0), controller,curve: Curves.bounceInOut),
-        child: child,
-     );
-  },
-  reverseAnimBuilder: (BuildContext context,AnimationController controller,Duration duration,Widget child,){ // Builder method for custom reverse animation
-     return SlideTransition(
-        position: getAnimation<Offset>(Offset(0.0, 0.0),Offset(-3.0,0), controller,curve: Curves.bounceInOut),
-        child: child,
-     );
-  },
-  child: MaterialApp(
-          title: appTitle,
-          showPerformanceOverlay: showPerformance,
-          home: LayoutBuilder(
-            builder: (BuildContext context, BoxConstraints constraints) {
-              return MyHomePage(
-                title: appTitle,
-                onSetting: onSettingCallback,
-              );
-            },
-          ),
-        ),
-);
-```dart
+return StyledToast(
+          textStyle: TextStyle(
+              fontSize: 16.0,
+              color: Colors.white), //Default text style of toast
+          backgroundColor: Color(0x99000000), //Background color of toast
+          borderRadius: BorderRadius.circular(5.0), //Border radius of toast
+          textPadding: EdgeInsets.symmetric(
+              horizontal: 17.0, vertical: 10.0), //The padding of toast text
+          toastPositions: StyledToastPosition.bottom, //The position of toast
+          toastAnimation:
+              StyledToastAnimation.fade, //The animation type of toast
+          reverseAnimation: StyledToastAnimation
+              .fade, //The reverse animation of toast (display When dismiss toast)
+          curve: Curves.fastOutSlowIn, //The curve of animation
+          reverseCurve:
+              Curves.fastLinearToSlowEaseIn, //The curve of reverse animation
+          duration: Duration(
+              seconds:
+                  4), //The duration of toast showing, when set [duration] to Duration.zero, toast won't dismiss automatically.
+          animDuration: Duration(
+              seconds:
+                  1), //The duration of animation(including reverse) of toast
+          dismissOtherOnShow:
+              true, //When we show a toast and other toast is showing, dismiss any other showing toast before.
+
+          fullWidth:
+              false, //Whether the toast is full screen (subtract the horizontal margin)
+          isHideKeyboard: false, //Is hide keyboard when toast show
+          isIgnoring: true, //Is the input ignored for the toast
+          animationBuilder: (
+            BuildContext context,
+            AnimationController controller,
+            Duration duration,
+            Widget child,
+          ) {
+            // Builder method for custom animation
+            return SlideTransition(
+              position: getAnimation<Offset>(
+                  Offset(0.0, 3.0), Offset(0, 0), controller,
+                  curve: Curves.bounceInOut),
+              child: child,
+            );
+          },
+          reverseAnimBuilder: (
+            BuildContext context,
+            AnimationController controller,
+            Duration duration,
+            Widget child,
+          ) {
+            // Builder method for custom reverse animation
+            return SlideTransition(
+              position: getAnimation<Offset>(
+                  Offset(0.0, 0.0), Offset(-3.0, 0), controller,
+                  curve: Curves.bounceInOut),
+              child: child,
+            );
+          },
+          child: child ?? const SizedBox.shrink(),
+        );
+      },
+    );
+```
 
 ```dart
 //After global configuration, use in a single line.
@@ -379,26 +381,25 @@ showToastWidget(Text('hello styled toast'));
   </tr>
 </table>
 
-
 ### StyledToast param
 
 property             | description
 ---------------------|----------------------------
 locale               | Locale (Not Null)(required You have to set this parameters to your locale)
 child                | Widget (Not Null)(required)
-textAlign            | TextAlign (default TextAlign.center)    
+textAlign            | TextAlign (default TextAlign.center)
 textDirection        | TextDirection (default TextDirection.ltr)  
 borderRadius         | BorderRadius (BorderRadius.circular(5.0))
 backgroundColor      | Color (default Color(0x99000000))
-textPadding          | EdgeInsetsGeometry (default EdgeInsets.symmetric(horizontal: 17.0,vertical: 8.0))   
-toastHorizontalMargin| double (default 50.0)   
-textStyle            | TextStyle (default TextStyle(fontSize: 16.0,fontWeight: FontWeight.normal,color: Colors.white))   
+textPadding          | EdgeInsetsGeometry (default EdgeInsets.symmetric(horizontal: 17.0,vertical: 8.0))
+toastHorizontalMargin| double (default 50.0)
+textStyle            | TextStyle (default TextStyle(fontSize: 16.0,fontWeight: FontWeight.normal,color: Colors.white))
 shapeBorder          | ShapeBorder (default RoundedRectangleBorder(borderRadius: borderRadius))
 duration             | Duration (default 2.3s)(When set [duration] to Duration.zero, toast won't dismiss automatically)
 animDuration         | Duration (default 400 milliseconds, animDuration * 2  <= duration, conditions must be met for toast to display properly)
 toastPositions       | StyledToastPosition (default StyledToastPosition.bottom)
 toastAnimation       | StyledToastAnimation (default StyledToastAnimation.fade)
-reverseAnimation     | StyledToastAnimation 
+reverseAnimation     | StyledToastAnimation
 alignment            | AlignmentGeometry (default Alignment.center)
 axis                 | Axis (default Axis.vertical)
 startOffset          | Offset
@@ -407,7 +408,7 @@ reverseStartOffset   | Offset
 reverseEndOffset     | Offset
 curve                | Curve (default Curves.linear)
 reverseCurve         | Curve (default Curves.linear)
-dismissOtherOnShow   | bool (default true)     
+dismissOtherOnShow   | bool (default true)
 onDismiss            | VoidCallback (Invoked when toast dismiss)
 fullWidth            | bool (default false)(Full width parameter that the width of the screen minus the width of the margin.)
 isHideKeyboard       | bool (default false)(Is hide keyboard when toast show)
@@ -415,8 +416,6 @@ animationBuilder     | CustomAnimationBuilder (Builder method for custom animati
 reverseAnimBuilder   | CustomAnimationBuilder (Builder method for custom reverse animation)
 isIgnoring           | bool (default true)
 onInitState          | OnInitStateCallback (When toast widget [initState], this callback will be called)
-
-
 
 ### showToast param
 
@@ -427,24 +426,24 @@ context              | BuildContext (If you don't wrap app with StyledToast, con
 duration             | Duration (default 2.3s)(When set [duration] to Duration.zero, toast won't dismiss automatically)
 animDuration         | Duration (default 400 milliseconds, animDuration * 2  <= duration, conditions must be met for toast to display properly)
 position             | StyledToastPosition (default StyledToastPosition.bottom)
-textStyle            | TextStyle (default TextStyle(fontSize: 16.0,fontWeight: FontWeight.normal,color: Colors.white))   
-textPadding          | EdgeInsetsGeometry (default EdgeInsets.symmetric(horizontal: 17.0,vertical: 8.0))   
+textStyle            | TextStyle (default TextStyle(fontSize: 16.0,fontWeight: FontWeight.normal,color: Colors.white))
+textPadding          | EdgeInsetsGeometry (default EdgeInsets.symmetric(horizontal: 17.0,vertical: 8.0))
 backgroundColor      | Color (default Color(0x99000000))
 borderRadius         | BorderRadius (BorderRadius.circular(5.0))
-shapeBorder          | ShapeBorder (default RoundedRectangleBorder(borderRadius: borderRadius))   
-onDismiss            | VoidCallback (Invoked when toast dismiss) 
+shapeBorder          | ShapeBorder (default RoundedRectangleBorder(borderRadius: borderRadius))
+onDismiss            | VoidCallback (Invoked when toast dismiss)
 textDirection        | TextDirection (default TextDirection.ltr)  
-dismissOtherOnShow   | bool (default true)     
+dismissOtherOnShow   | bool (default true)
 toastAnimation       | StyledToastAnimation (default StyledToastAnimation.fade)
-reverseAnimation     | StyledToastAnimation 
+reverseAnimation     | StyledToastAnimation
 alignment            | AlignmentGeometry (default Alignment.center)
 axis                 | Axis (default Axis.vertical)
 startOffset          | Offset
 endOffset            | Offset
 reverseStartOffset   | Offset
 reverseEndOffset     | Offset
-textAlign            | TextAlign (default TextAlign.center)    
-curve                | Curve (default Curves.linear)    
+textAlign            | TextAlign (default TextAlign.center)
+curve                | Curve (default Curves.linear)
 reverseCurve         | Curve (default Curves.linear)
 fullWidth            | bool (default false)(Full width parameter that the width of the screen minus the width of the margin)
 isHideKeyboard       | bool (default false)(Is hide keyboard when toast show)
@@ -452,8 +451,6 @@ animationBuilder     | CustomAnimationBuilder (Builder method for custom animati
 reverseAnimBuilder   | CustomAnimationBuilder (Builder method for custom reverse animation)
 isIgnoring           | bool (default true)(Is the input ignored for the toast)
 onInitState          | OnInitStateCallback (When toast widget [initState], this callback will be called)
-
-
 
 ### showToastWidget param
 
@@ -463,19 +460,19 @@ widget               | Widget (Not Null)(required)
 context              | BuildContext (If you don't wrap app with StyledToast, context is required, otherwise, is not)
 duration             | Duration (default 2.3s)(When set [duration] to Duration.zero, toast won't dismiss automatically)
 animDuration         | Duration (default 400 milliseconds, animDuration * 2  <= duration, conditions must be met for toast to display properly)
-onDismiss            | VoidCallback (Invoked when toast dismiss) 
-dismissOtherOnShow   | bool (default true)        
+onDismiss            | VoidCallback (Invoked when toast dismiss)
+dismissOtherOnShow   | bool (default true)
 textDirection        | TextDirection (default TextDirection.ltr)
 position             | StyledToastPosition (default )
 animation            | StyledToastAnimation (default StyledToastAnimation.fade)
-reverseAnimation     | StyledToastAnimation 
+reverseAnimation     | StyledToastAnimation
 alignment            | AlignmentGeometry (default Alignment.center)
 axis                 | Axis (default Axis.vertical)
 startOffset          | Offset
 endOffset            | Offset
 reverseStartOffset   | Offset
 reverseEndOffset     | Offset
-curve                | Curve (default Curves.linear)    
+curve                | Curve (default Curves.linear)
 reverseCurve         | Curve (default Curves.linear)
 isHideKeyboard       | bool (default false)(Is hide keyboard when toast show)
 animationBuilder     | CustomAnimationBuilder (Builder method for custom animation)
@@ -483,7 +480,6 @@ reverseAnimBuilder   | CustomAnimationBuilder (Builder method for custom reverse
 isIgnoring           | bool (default true )(Is the input ignored for the toast)
 onInitState          | OnInitStateCallback (When toast widget [initState], this callback will be called)
 
-
 ## Example
-[example](https://github.com/JackJonson/flutter_styled_toast/blob/master/example/lib/main.dart)
 
+[example](https://github.com/JackJonson/flutter_styled_toast/blob/master/example/lib/main.dart)

--- a/example/.metadata
+++ b/example/.metadata
@@ -4,7 +4,27 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: 7a4c33425ddd78c54aba07d86f3f9a4a0051769b
-  channel: stable
+  revision: "db7ef5bf9f59442b0e200a90587e8fa5e0c6336a"
+  channel: "stable"
 
 project_type: app
+
+# Tracks metadata for the flutter migrate command
+migration:
+  platforms:
+    - platform: root
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+    - platform: android
+      create_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+      base_revision: db7ef5bf9f59442b0e200a90587e8fa5e0c6336a
+
+  # User provided section
+
+  # List of Local paths (relative to this file) that should be
+  # ignored by the migrate tool.
+  #
+  # Files that are not part of the templates will be ignored by default.
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,0 +1,28 @@
+# This file configures the analyzer, which statically analyzes Dart code to
+# check for errors, warnings, and lints.
+#
+# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
+# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
+# invoked from the command line by running `flutter analyze`.
+
+# The following line activates a set of recommended lints for Flutter apps,
+# packages, and plugins designed to encourage good coding practices.
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  # The lint rules applied to this project can be customized in the
+  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
+  # included above or to enable additional rules. A list of all available lints
+  # and their documentation is published at https://dart.dev/lints.
+  #
+  # Instead of disabling a lint rule for the entire project in the
+  # section below, it can also be suppressed for a single line of code
+  # or a specific dart file by using the `// ignore: name_of_lint` and
+  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
+  # producing the lint.
+  rules:
+    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
+    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/example/android/.gitignore
+++ b/example/android/.gitignore
@@ -1,0 +1,13 @@
+gradle-wrapper.jar
+/.gradle
+/captures/
+/gradlew
+/gradlew.bat
+/local.properties
+GeneratedPluginRegistrant.java
+
+# Remember to never publicly share your keystore.
+# See https://flutter.dev/docs/deployment/android#reference-the-keystore-from-the-app
+key.properties
+**/*.keystore
+**/*.jks

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,14 +1,15 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -21,24 +22,33 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-
 android {
-    compileSdkVersion 28
+    namespace "com.jackjonson.example"
+    compileSdkVersion flutter.compileSdkVersion
+    ndkVersion flutter.ndkVersion
 
-    lintOptions {
-        disable 'InvalidPackage'
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
     }
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.jackjonson.example"
-        minSdkVersion 16
-        targetSdkVersion 28
+        // You can update the following values to match your application needs.
+        // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -54,8 +64,4 @@ flutter {
     source '../..'
 }
 
-dependencies {
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-}
+dependencies {}

--- a/example/android/app/src/debug/AndroidManifest.xml
+++ b/example/android/app/src/debug/AndroidManifest.xml
@@ -1,6 +1,6 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.jackjonson.example">
-    <!-- Flutter needs it to communicate with the running application
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- The INTERNET permission is required for development. Specifically,
+         the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,45 +1,33 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.jackjonson.example">
-
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
-         In most cases you can leave this as-is, but you if you want to provide
-         additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
+        android:label="example"
         android:name="${applicationName}"
-        android:label="flutter_styled_toast_example"
         android:icon="@mipmap/ic_launcher">
-
-        <meta-data
-            android:name="flutterEmbedding"
-            android:value="2" />
-
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
-            <!-- This keeps the window background of the activity showing
-                 until Flutter renders its first frame. It can be removed if
-                 there is no splash screen (such as the default splash screen
-                 defined in @style/LaunchTheme). -->
-
+            <!-- Specifies an Android theme to apply to this Activity as soon as
+                 the Android process has started. This theme is visible to the user
+                 while the Flutter UI initializes. After that, this theme continues
+                 to determine the Window background behind the Flutter UI. -->
             <meta-data
-                android:name="io.flutter.embedding.android.SplashScreenDrawable"
-                android:resource="@drawable/launch_background" />
-
-            <!-- Theme to apply as soon as Flutter begins rendering frames -->
-            <meta-data
-                android:name="io.flutter.embedding.android.NormalTheme"
-                android:resource="@style/NormalTheme"
-                />
+              android:name="io.flutter.embedding.android.NormalTheme"
+              android:resource="@style/NormalTheme"
+              />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- Don't delete the meta-data below.
+             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/example/android/app/src/main/java/com/jackjonson/example/MainActivity.java
+++ b/example/android/app/src/main/java/com/jackjonson/example/MainActivity.java
@@ -1,6 +1,0 @@
-package com.jackjonson.example;
-
-import io.flutter.embedding.android.FlutterActivity;
-
-public class MainActivity extends FlutterActivity {
-}

--- a/example/android/app/src/main/kotlin/com/jackjonson/example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/jackjonson/example/MainActivity.kt
@@ -1,0 +1,6 @@
+package com.jackjonson.example
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity: FlutterActivity() {
+}

--- a/example/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/example/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Modify this file to customize your launch splash screen -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@android:color/black" />
+    <item android:drawable="?android:colorBackground" />
 
     <!-- You can insert your own image assets here -->
     <!-- <item>

--- a/example/android/app/src/main/res/values-night/styles.xml
+++ b/example/android/app/src/main/res/values-night/styles.xml
@@ -3,14 +3,14 @@
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is on -->
     <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <!-- Show a splash screen on the activity. Automatically removed when
-             Flutter draws its first frame -->
+             the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your
          Flutter UI initializes, as well as behind your Flutter UI while its
          running.
-         
+
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>

--- a/example/android/app/src/main/res/values/styles.xml
+++ b/example/android/app/src/main/res/values/styles.xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is off -->
+    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
         <!-- Show a splash screen on the activity. Automatically removed when
-             Flutter draws its first frame -->
+             the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
     </style>
-    <!-- You can name this style whatever you'd like -->
-    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
-        <item name="android:windowBackground">@drawable/normal_background</item>
+    <!-- Theme applied to the Android Window as soon as the process has started.
+         This theme determines the color of the Android Window while your
+         Flutter UI initializes, as well as behind your Flutter UI while its
+         running.
+
+         This Theme is only used starting with V2 of Flutter's Android embedding. -->
+    <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
+        <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/example/android/app/src/profile/AndroidManifest.xml
+++ b/example/android/app/src/profile/AndroidManifest.xml
@@ -1,6 +1,6 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.jackjonson.example">
-    <!-- Flutter needs it to communicate with the running application
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- The INTERNET permission is required for development. Specifically,
+         the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,18 +1,19 @@
 buildscript {
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.3'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -24,6 +25,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,2 +1,3 @@
-org.gradle.jvmargs=-Xmx1536M
-android.enableR8=true
+org.gradle.jvmargs=-Xmx4G
+android.useAndroidX=true
+android.enableJetifier=true

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,15 +1,29 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }
+    settings.ext.flutterSdkPath = flutterSdkPath()
 
-def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
+    includeBuild("${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle")
 
-def plugins = new Properties()
-def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
-if (pluginsFile.exists()) {
-    pluginsFile.withReader('UTF-8') { reader -> plugins.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
+    plugins {
+        id "dev.flutter.flutter-gradle-plugin" version "1.0.0" apply false
+    }
 }
 
-plugins.each { name, path ->
-    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
-    include ":$name"
-    project(":$name").projectDir = pluginDirectory
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "7.3.0" apply false
 }
+
+include ":app"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,38 +29,41 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     final appTitle = 'Styled Toast Example';
-    return StyledToast(
-      textStyle: TextStyle(fontSize: 16.0, color: Colors.white),
-      backgroundColor: Color(0x99000000),
-      borderRadius: BorderRadius.circular(5.0),
-      textPadding: EdgeInsets.symmetric(horizontal: 17.0, vertical: 10.0),
-      toastAnimation: StyledToastAnimation.size,
-      reverseAnimation: StyledToastAnimation.size,
-      startOffset: Offset(0.0, -1.0),
-      reverseEndOffset: Offset(0.0, -1.0),
-      duration: Duration(seconds: 4),
-      animDuration: Duration(seconds: 1),
-      alignment: Alignment.center,
-      toastPositions: StyledToastPosition.center,
-      curve: Curves.fastOutSlowIn,
-      reverseCurve: Curves.fastOutSlowIn,
-      dismissOtherOnShow: true,
-      locale: const Locale('en', 'US'),
-      fullWidth: false,
-      isHideKeyboard: false,
-      isIgnoring: true,
-      child: MaterialApp(
-        title: appTitle,
-        showPerformanceOverlay: showPerformance,
-        home: LayoutBuilder(
-          builder: (BuildContext context, BoxConstraints constraints) {
-            return MyHomePage(
-              title: appTitle,
-              onSetting: onSettingCallback,
-            );
-          },
-        ),
+    return MaterialApp(
+      title: appTitle,
+      theme: ThemeData(useMaterial3: true),
+      showPerformanceOverlay: showPerformance,
+      home: LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+          return MyHomePage(
+            title: appTitle,
+            onSetting: onSettingCallback,
+          );
+        },
       ),
+      builder: (context, child) {
+        return StyledToast(
+          textStyle: TextStyle(fontSize: 16.0, color: Colors.white),
+          backgroundColor: Color(0x99000000),
+          borderRadius: BorderRadius.circular(5.0),
+          textPadding: EdgeInsets.symmetric(horizontal: 17.0, vertical: 10.0),
+          toastAnimation: StyledToastAnimation.size,
+          reverseAnimation: StyledToastAnimation.size,
+          startOffset: Offset(0.0, -1.0),
+          reverseEndOffset: Offset(0.0, -1.0),
+          duration: Duration(seconds: 4),
+          animDuration: Duration(seconds: 1),
+          alignment: Alignment.center,
+          toastPositions: StyledToastPosition.center,
+          curve: Curves.fastOutSlowIn,
+          reverseCurve: Curves.fastOutSlowIn,
+          dismissOtherOnShow: true,
+          fullWidth: false,
+          isHideKeyboard: false,
+          isIgnoring: true,
+          child: child ?? const SizedBox.shrink(),
+        );
+      },
     );
   }
 }
@@ -95,10 +98,14 @@ class _MyHomePageState extends State<MyHomePage>
   @override
   void initState() {
     super.initState();
-    mController =
-        AnimationController(vsync: this, duration: Duration(milliseconds: 200));
-    mReverseController =
-        AnimationController(vsync: this, duration: Duration(milliseconds: 200));
+    mController = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: 200),
+    );
+    mReverseController = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: 200),
+    );
   }
 
   @override
@@ -117,13 +124,9 @@ class _MyHomePageState extends State<MyHomePage>
       ),
       body: Center(
         child: ListView(
-          padding: EdgeInsets.symmetric(horizontal: 30.0, vertical: 20.0),
+          padding: EdgeInsets.symmetric(vertical: 4),
           children: <Widget>[
-            TextField(
-              controller: TextEditingController(),
-            ),
             Container(
-              margin: EdgeInsets.only(bottom: 10.0),
               padding: EdgeInsets.only(left: 15.0),
               height: 35.0,
               alignment: Alignment.centerLeft,
@@ -600,8 +603,7 @@ class _MyHomePageState extends State<MyHomePage>
               },
             ),
             Divider(
-              height: 10,
-              thickness: 10,
+              height: 0.5,
             ),
             ListTile(
               title: Text(
@@ -778,7 +780,6 @@ class _MyHomePageState extends State<MyHomePage>
 
             ///Custom toast content widget
             Container(
-              margin: EdgeInsets.only(bottom: 10.0, top: 50.0),
               padding: EdgeInsets.only(left: 15.0),
               height: 35.0,
               alignment: Alignment.centerLeft,

--- a/lib/src/styled_toast.dart
+++ b/lib/src/styled_toast.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
+
 import 'custom_animation.dart';
 import 'custom_size_transition.dart';
 import 'styled_toast_enum.dart';
@@ -342,9 +342,6 @@ class StyledToast extends StatefulWidget {
   /// Dismiss old toast when new one shows.
   final bool? dismissOtherOnShow;
 
-  /// The locale of the app.
-  final Locale locale;
-
   /// Full width that the width of the screen minus the width of the margin.
   final bool? fullWidth;
 
@@ -388,7 +385,6 @@ class StyledToast extends StatefulWidget {
     this.reverseCurve,
     this.dismissOtherOnShow = true,
     this.onDismiss,
-    required this.locale,
     this.fullWidth,
     this.isHideKeyboard,
     this.animationBuilder,
@@ -419,11 +415,7 @@ class _StyledToastState extends State<StyledToast> {
 
     final wrapper = Directionality(
       textDirection: textDirection,
-      child: Stack(
-        children: <Widget>[
-          overlay,
-        ],
-      ),
+      child: overlay,
     );
 
     final textStyle = widget.textStyle ??
@@ -444,44 +436,36 @@ class _StyledToastState extends State<StyledToast> {
           vertical: 8.0,
         );
 
-    return Localizations(
-      delegates: const [
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ],
-      locale: widget.locale,
-      child: StyledToastTheme(
-        textAlign: textAlign,
-        textDirection: textDirection,
-        borderRadius: borderRadius,
-        backgroundColor: backgroundColor,
-        textPadding: textPadding,
-        textStyle: textStyle,
-        shapeBorder: widget.shapeBorder,
-        duration: widget.duration,
-        animDuration: widget.animDuration,
-        toastPositions: widget.toastPositions,
-        toastAnimation: widget.toastAnimation,
-        reverseAnimation: widget.reverseAnimation,
-        alignment: widget.alignment,
-        axis: widget.axis,
-        startOffset: widget.startOffset,
-        endOffset: widget.endOffset,
-        reverseStartOffset: widget.reverseStartOffset,
-        reverseEndOffset: widget.reverseEndOffset,
-        curve: widget.curve,
-        reverseCurve: widget.reverseCurve,
-        dismissOtherOnShow: widget.dismissOtherOnShow,
-        onDismiss: widget.onDismiss,
-        fullWidth: widget.fullWidth,
-        isHideKeyboard: widget.isHideKeyboard,
-        animationBuilder: widget.animationBuilder,
-        reverseAnimBuilder: widget.reverseAnimBuilder,
-        isIgnoring: widget.isIgnoring,
-        onInitState: widget.onInitState,
-        child: wrapper,
-      ),
+    return StyledToastTheme(
+      textAlign: textAlign,
+      textDirection: textDirection,
+      borderRadius: borderRadius,
+      backgroundColor: backgroundColor,
+      textPadding: textPadding,
+      textStyle: textStyle,
+      shapeBorder: widget.shapeBorder,
+      duration: widget.duration,
+      animDuration: widget.animDuration,
+      toastPositions: widget.toastPositions,
+      toastAnimation: widget.toastAnimation,
+      reverseAnimation: widget.reverseAnimation,
+      alignment: widget.alignment,
+      axis: widget.axis,
+      startOffset: widget.startOffset,
+      endOffset: widget.endOffset,
+      reverseStartOffset: widget.reverseStartOffset,
+      reverseEndOffset: widget.reverseEndOffset,
+      curve: widget.curve,
+      reverseCurve: widget.reverseCurve,
+      dismissOtherOnShow: widget.dismissOtherOnShow,
+      onDismiss: widget.onDismiss,
+      fullWidth: widget.fullWidth,
+      isHideKeyboard: widget.isHideKeyboard,
+      animationBuilder: widget.animationBuilder,
+      reverseAnimBuilder: widget.reverseAnimBuilder,
+      isIgnoring: widget.isIgnoring,
+      onInitState: widget.onInitState,
+      child: wrapper,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_styled_toast
 description: A Styled Toast Flutter package. You can highly customize toast
   ever.Beautify toast with a series of animations and make toast more beautiful.
-version: 2.2.1
+version: 2.3.0
 homepage: https://github.com/JackJonson/flutter_styled_toast
 email: yswing1@gmail.com
 

--- a/test/custom_animation_test.dart
+++ b/test/custom_animation_test.dart
@@ -122,7 +122,6 @@ class CustomAnimationTestAppWidgetState
       curve: Curves.fastOutSlowIn,
       reverseCurve: Curves.fastOutSlowIn,
       dismissOtherOnShow: true,
-      locale: const Locale('en', 'US'),
       fullWidth: false,
       isHideKeyboard: false,
       isIgnoring: true,

--- a/test/styled_toast_test.dart
+++ b/test/styled_toast_test.dart
@@ -54,7 +54,6 @@ void main() {
         curve: curve,
         reverseCurve: reverseCurve,
         dismissOtherOnShow: dismissOtherOnShow,
-        locale: const Locale('en', 'US'),
         fullWidth: fullWidth,
         isHideKeyboard: isHideKeyboard,
         isIgnoring: isIgnoring,
@@ -62,7 +61,6 @@ void main() {
       );
       await tester.pumpWidget(styledToast);
       await tester.pump(const Duration(milliseconds: 1000));
-      expect(styledToast.locale, const Locale('en', 'US'));
       expect(styledToast.textStyle,
           const TextStyle(fontSize: 16.0, color: Colors.white));
       expect(styledToast.backgroundColor, const Color(0x99000000));
@@ -244,7 +242,6 @@ class TestAppWidgetState extends State<TestAppWidget> {
       curve: Curves.fastOutSlowIn,
       reverseCurve: Curves.fastOutSlowIn,
       dismissOtherOnShow: true,
-      locale: const Locale('en', 'US'),
       fullWidth: false,
       isHideKeyboard: false,
       isIgnoring: true,


### PR DESCRIPTION
I have faced an issue when using Google's `flutter_localizations` package. When using `StyledToast` widget, the localizaiton delegates get overriden and access to my custom localizations gets lost. Moreover, I have found that locale params were unused and thus redundant.

Introduced fixes:
- Remove locale, fixing the bug
- Update how `StyledToast` is built into the `MaterialApp`
- Update android example, so that it runs
- Update README to reflect the changes 


P.S. I have decided to not use the package in my project, however I want to save people's time debugging this issue.