### PR TITLE
Added positioned widget to the overlay so that the overlay wont take up the entire space on the screen

### DIFF
--- a/lib/flutter_styled_toast.dart
+++ b/lib/flutter_styled_toast.dart
@@ -6,3 +6,4 @@ export 'src/styled_toast_manage.dart';
 export 'src/custom_size_transition.dart';
 export 'src/custom_animation.dart';
 export 'src/styled_toast_theme.dart';
+export 'src/position_model.dart';

--- a/lib/src/position_model.dart
+++ b/lib/src/position_model.dart
@@ -1,0 +1,17 @@
+class OverlayPosition {
+  final double? left;
+  final double? top;
+  final double? right;
+  final double? bottom;
+  final double? width;
+  final double? height;
+
+  const OverlayPosition({
+    this.left,
+    this.top,
+    this.right,
+    this.bottom,
+    this.width,
+    this.height,
+  });
+}

--- a/lib/src/styled_toast.dart
+++ b/lib/src/styled_toast.dart
@@ -7,6 +7,7 @@ import 'custom_size_transition.dart';
 import 'styled_toast_enum.dart';
 import 'styled_toast_manage.dart';
 import 'styled_toast_theme.dart';
+import 'position_model.dart';
 
 /// Current context of the page which uses the toast.
 BuildContext? currentContext;
@@ -164,6 +165,7 @@ ToastFuture showToastWidget(
   CustomAnimationBuilder? reverseAnimBuilder,
   bool? isIgnoring,
   OnInitStateCallback? onInitState,
+  OverlayPosition? overlayPosition,
 }) {
   OverlayEntry entry;
   ToastFuture future;
@@ -227,31 +229,39 @@ ToastFuture showToastWidget(
   GlobalKey<StyledToastWidgetState> key = GlobalKey();
 
   entry = OverlayEntry(builder: (ctx) {
-    return IgnorePointer(
-      ignoring: isIgnoring!,
-      child: _StyledToastWidget(
-        duration: duration!,
-        animDuration: animDuration!,
-        position: position,
-        animation: animation,
-        reverseAnimation: reverseAnimation,
-        alignment: alignment,
-        axis: axis,
-        startOffset: startOffset,
-        endOffset: endOffset,
-        reverseStartOffset: reverseStartOffset,
-        reverseEndOffset: reverseEndOffset,
-        curve: curve!,
-        reverseCurve: reverseCurve!,
-        key: key,
-        animationBuilder: animationBuilder,
-        reverseAnimBuilder: reverseAnimBuilder,
-        onInitState: onInitState,
-        child: Directionality(
-          textDirection: textDirection!,
-          child: Material(
-            child: widget,
-            color: Colors.transparent,
+    return Positioned(
+      top: overlayPosition?.top,
+      bottom: overlayPosition?.bottom,
+      left: overlayPosition?.left,
+      right: overlayPosition?.right,
+      height: overlayPosition?.height,
+      width: overlayPosition?.width,
+      child: IgnorePointer(
+        ignoring: isIgnoring!,
+        child: _StyledToastWidget(
+          duration: duration!,
+          animDuration: animDuration!,
+          position: position,
+          animation: animation,
+          reverseAnimation: reverseAnimation,
+          alignment: alignment,
+          axis: axis,
+          startOffset: startOffset,
+          endOffset: endOffset,
+          reverseStartOffset: reverseStartOffset,
+          reverseEndOffset: reverseEndOffset,
+          curve: curve!,
+          reverseCurve: reverseCurve!,
+          key: key,
+          animationBuilder: animationBuilder,
+          reverseAnimBuilder: reverseAnimBuilder,
+          onInitState: onInitState,
+          child: Directionality(
+            textDirection: textDirection!,
+            child: Material(
+              child: widget,
+              color: Colors.transparent,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
 I added this because i had a button near the toast. The button was not clickable since the overlay was filling the whole screen. Please check the sample video attached, in which i have shown the before and after adding the Positioned widget.

In the video, i am not able to click the "press" button when toast is on the screen. But after adding the positioned widget i can click the "press" button even when the toast is being shown.

https://github.com/JackJonson/flutter_styled_toast/assets/58786637/4f1ad8e4-1fbd-43e9-9955-628cbb07933f

